### PR TITLE
add reassign group ownership when leaving

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -20,8 +20,9 @@
   <% res = current_user.getTeam %>
 
   <% if res.empty? %>
-    <div class="none">No Group</div>
-    <%= link_to "Change Groups", join_group_path(current_user), :class => "btn btn-secondary" %>
+    <div class="none">You are not in a group. Create or join one below to get started!</div>
+    <br>
+    <%= link_to "Join Group", join_group_path(current_user), :class => "btn btn-secondary" %>
     <%= link_to "Create a Group", new_group_path, :class => "btn btn-primary" %>
   <% else %>
     <% pull_date = current_user.pullTime %>
@@ -126,9 +127,7 @@
       <% end %>
     </ul>
     <br>
-    <% unless current_user.group_owner? %>
       <%= link_to "Change Groups", join_group_path(current_user), :class => "btn btn-secondary" %> <%= button_to 'Leave Group', leave_group_user_path(current_user[:id]), :class => "btn btn-danger" %>
-    <% end %>
     <br>
   <% end %>
   <br>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -62,6 +62,7 @@ more_users = [
   { uin: 327000005, pulled: false, group_id: 1, admin: false },
   { uin: 327000006, pulled: false, group_id: 1, admin: false },
   { uin: 327000007, pulled: false, group_id: 1, admin: false },
+  { uin: 327000008, pulled: false, group_id: 1, admin: false },
   { uin: 1, pulled: false, group_id: nil, admin: true }
 ]
 


### PR DESCRIPTION
- if user wants to leave or change group and is currently group owner, the next user in the group will be automatically assigned ownership
- if the user is the only user in the group, that group will be deleted when they leave